### PR TITLE
feat(Corpán): sticky X on settings modal y más

### DIFF
--- a/corpan/corpan-app/src/App.tsx
+++ b/corpan/corpan-app/src/App.tsx
@@ -2,10 +2,11 @@ import { useSettingsStore, ALL_TEXT_SIZES } from "@/store/settings";
 import { OnboardingWizard } from "@/components/OnboardingWizard";
 import { SettingsIcon } from "lucide-react";
 import { useState, useEffect } from "react";
-import { getPlatformTopPaddingButtons, MainExperience } from "./components/MainExperience";
+import { MainExperience } from "./components/MainExperience";
 import { SettingsModal } from "./components/SettingsModal";
 import { Button } from "./components/ui/button";
 import "./index.css";
+import { getPlatformTopPaddingButtons } from "./util/browser";
 
 
 export default function App() {

--- a/corpan/corpan-app/src/components/MainExperience.tsx
+++ b/corpan/corpan-app/src/components/MainExperience.tsx
@@ -17,35 +17,12 @@ import { createVoiceTTS } from "@/util/speak";
 import { useTranslation } from "react-i18next";
 
 import { isRTL, toCamelCase } from "@/util/convert";
-import { isAndroid } from "@/util/browser";
-
-
-export function getPlatformBottomPadding() {
-    if (/iPhone|iPad|iPod|iOS/i.test(navigator.userAgent)) {
-        return 180;
-    } if (/Android/i.test(navigator.userAgent)) {
-        return 195;
-    }
-    return 180;
-}
-
-export function getPlatformTopPaddingButtons() {
-    if (/iPhone|iPad|iPod|iOS/i.test(navigator.userAgent)) {
-        return 55;
-    } if (/Android/i.test(navigator.userAgent)) {
-        return 27;
-    }
-    return 0;
-}
-
-export function getPlatformTopPaddingTranslations() {
-    if (/iPhone|iPad|iPod|iOS/i.test(navigator.userAgent)) {
-        return 150;
-    } if (/Android/i.test(navigator.userAgent)) {
-        return 125;
-    }
-    return 75;
-}
+import {
+    getPlatformBottomPadding,
+    getPlatformTopPaddingButtons,
+    getPlatformTopPaddingTranslations,
+    isAndroid,
+} from "@/util/browser";
 
 // // Even lamer but still fine
 // const paddingAdjustMap: Record<string, number> = {

--- a/corpan/corpan-app/src/components/MainExperience.tsx
+++ b/corpan/corpan-app/src/components/MainExperience.tsx
@@ -196,7 +196,8 @@ export function MainExperience() {
 
                                 <motion.div
                                     whileTap={{ scale: 0.9 }}
-                                    transition={{ type: "spring", stiffness: 133, damping: 7 }}
+                                    transition={{ type: "spring", stiffness: 100, damping: 10 }}
+                                    className="transform-gpu will-change-transform"
                                 >
                                     <Button
                                         className="mt-1"
@@ -204,11 +205,12 @@ export function MainExperience() {
                                         variant="outline"
                                         style={{ cursor: "pointer" }}
                                     >
-                                        <Speaker className="w-3 h-3" />
-                                        <AudioLines className="w-3 h-3" />
-                                        <Ear className="w-3 h-3" />
+                                        <Speaker className="shrink-0" />
+                                        <AudioLines className="shrink-0" />
+                                        <Ear className="shrink-0" />
                                     </Button>
                                 </motion.div>
+
                             </div>
                         </motion.div>
                     ))}

--- a/corpan/corpan-app/src/components/SettingsModal.tsx
+++ b/corpan/corpan-app/src/components/SettingsModal.tsx
@@ -44,8 +44,8 @@ export function SettingsModal({
                     flex flex-col
                 "
         style={{
-          paddingBottom: "2rem",
-          paddingTop: "5rem",
+          // paddingBottom: "2rem",
+          // paddingTop: "5rem",
         }}
         id="settings-modal-content"
       >

--- a/corpan/corpan-app/src/components/ui/dialog.tsx
+++ b/corpan/corpan-app/src/components/ui/dialog.tsx
@@ -4,6 +4,13 @@ import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+import {
+  // getPlatformBottomPadding,
+  getPlatformTopPaddingButtons,
+  // getPlatformTopPaddingTranslations,
+  // isAndroid,
+} from "@/util/browser";
+
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
@@ -60,11 +67,21 @@ function DialogContent({
         )}
         {...props}
       >
-        {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-17 right-7 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon className="size-10" />
+        {/* Move Close BEFORE children and make it sticky */}
+        <DialogPrimitive.Close
+          // className="sticky top-0 z-1001 ml-auto inline-flex items-center justify-center rounded-md border bg-background p-1 shadow-sm cursor-pointer transition-all hover:shadow-md hover:bg-accent/5 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none pointer-events-auto"
+          className="sticky top-0 z-[1001] ml-auto inline-flex items-center justify-center rounded-md border bg-background p-1 shadow-sm cursor-pointer transition-all hover:shadow-md hover:bg-background focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none pointer-events-auto"
+        >
+          <XIcon className="size-10"
+            style={{
+              marginTop: getPlatformTopPaddingButtons(),
+            }}
+
+          />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
+
+        {children}
       </DialogPrimitive.Content>
     </DialogPortal>
   )

--- a/corpan/corpan-app/src/components/ui/dialog.tsx
+++ b/corpan/corpan-app/src/components/ui/dialog.tsx
@@ -66,18 +66,15 @@ function DialogContent({
           className
         )}
         {...props}
+        style={{
+          paddingTop: getPlatformTopPaddingButtons(),
+        }}
       >
         {/* Move Close BEFORE children and make it sticky */}
         <DialogPrimitive.Close
-          // className="sticky top-0 z-1001 ml-auto inline-flex items-center justify-center rounded-md border bg-background p-1 shadow-sm cursor-pointer transition-all hover:shadow-md hover:bg-accent/5 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none pointer-events-auto"
-          className="sticky top-0 z-[1001] ml-auto inline-flex items-center justify-center rounded-md border bg-background p-1 shadow-sm cursor-pointer transition-all hover:shadow-md hover:bg-background focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none pointer-events-auto"
+          className="sticky top-3 z-[1001] ml-auto inline-flex items-center justify-center rounded-md border bg-background p-1 shadow-sm cursor-pointer transition-all hover:shadow-md hover:bg-background focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none pointer-events-auto"
         >
-          <XIcon className="size-10"
-            style={{
-              marginTop: getPlatformTopPaddingButtons(),
-            }}
-
-          />
+          <XIcon className="size-8" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>
 

--- a/corpan/corpan-app/src/util/browser.ts
+++ b/corpan/corpan-app/src/util/browser.ts
@@ -6,3 +6,29 @@ export function isIOS() {
     return /iPhone|iPad|iPod|iOS/i.test(navigator.userAgent);
 }
 
+export function getPlatformBottomPadding() {
+    if (/iPhone|iPad|iPod|iOS/i.test(navigator.userAgent)) {
+        return 180;
+    } if (/Android/i.test(navigator.userAgent)) {
+        return 195;
+    }
+    return 180;
+}
+
+export function getPlatformTopPaddingButtons() {
+    if (/iPhone|iPad|iPod|iOS/i.test(navigator.userAgent)) {
+        return 55;
+    } if (/Android/i.test(navigator.userAgent)) {
+        return 27;
+    }
+    return 0;
+}
+
+export function getPlatformTopPaddingTranslations() {
+    if (/iPhone|iPad|iPod|iOS/i.test(navigator.userAgent)) {
+        return 150;
+    } if (/Android/i.test(navigator.userAgent)) {
+        return 125;
+    }
+    return 75;
+}

--- a/corpan/corpan-app/src/util/browser.ts
+++ b/corpan/corpan-app/src/util/browser.ts
@@ -21,7 +21,7 @@ export function getPlatformTopPaddingButtons() {
     } if (/Android/i.test(navigator.userAgent)) {
         return 27;
     }
-    return 0;
+    return 10;
 }
 
 export function getPlatformTopPaddingTranslations() {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Centralize platform padding utilities in `util/browser`

- Make dialog close button sticky with padding

- Tweak button icon sizing and motion animation

- Remove redundant helpers from `MainExperience`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MainExp["MainExperience.tsx"] -- import padding utils --> BrowserUtil["util/browser.ts"]
  App["App.tsx"] -- move getPlatformTopPaddingButtons import --> BrowserUtil
  DialogUI["components/ui/dialog.tsx"] -- sticky Close uses padding --> BrowserUtil
  DialogUI -- improved UX --> SettingsModal["SettingsModal.tsx"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Import top padding helper from browser util</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/App.tsx

<ul><li>Move <code>getPlatformTopPaddingButtons</code> import to <code>util/browser</code>.<br> <li> Remove import from <code>MainExperience</code> path.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/90/files#diff-3068914b756d0c135f04421ae21e7c1b084f106462719c784e1635a7d9268c33">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainExperience.tsx</strong><dd><code>Use shared browser utils and refine animations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/components/MainExperience.tsx

<ul><li>Remove local platform padding helpers and <code>isAndroid</code>.<br> <li> Import padding helpers and <code>isAndroid</code> from <code>util/browser</code>.<br> <li> Adjust motion transition stiffness/damping.<br> <li> Update button/icon classes to prevent shrinking; add transform hints.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/90/files#diff-26ada68035a8a55e2d67b9e391856c6849baddef25ab261e53f34cd4d6df2f06">+12/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingsModal.tsx</strong><dd><code>Remove fixed padding from settings modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/components/SettingsModal.tsx

- Comment out hardcoded top/bottom padding in inline styles.


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/90/files#diff-ff21ab3565f447344aaee75a0ffacd3d0269c9d77015f0535f1d08f6ae1d7de0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dialog.tsx</strong><dd><code>Sticky close button with platform-aware offset</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/components/ui/dialog.tsx

<ul><li>Add import for <code>getPlatformTopPaddingButtons</code>.<br> <li> Reorder Close button before children.<br> <li> Make Close button sticky with high z-index.<br> <li> Apply platform-specific top margin to X icon.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/90/files#diff-062055e02d213885bffbb17614c41d60b009d7acba8d670513fb33c177b4985f">+20/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>browser.ts</strong><dd><code>Add shared platform padding utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

corpan/corpan-app/src/util/browser.ts

<ul><li>Add platform padding helpers: bottom, top buttons, translations.<br> <li> Centralize UA checks for iOS/Android paddings.</ul>


</details>


  </td>
  <td><a href="https://github.com/corpora-inc/encorpora/pull/90/files#diff-e5d4dbb1674c5ec0648a1225a61f31e6a749b884e571196528c6af4bf942b0b5">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

